### PR TITLE
readme: remove defunct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ See [FAQ](https://github.com/42wim/matterbridge/wiki/FAQ)
 - https://blog.valvin.fr/2016/09/17/mattermost-et-un-channel-irc-cest-possible/
 - https://blog.brightscout.com/top-10-mattermost-integrations/
 - http://bencey.co.nz/2018/09/17/bridge/
-- https://www.algoo.fr/blog/2018/01/19/recouvrez-votre-liberte-en-quittant-slack-pour-un-mattermost-auto-heberge/
 - https://kopano.com/blog/matterbridge-bridging-mattermost-chat/
 - https://www.stitcher.com/s/?eid=52382713
 - https://daniele.tech/2019/02/how-to-use-matterbridge-to-connect-2-different-slack-workspaces/


### PR DESCRIPTION
Remove link to now-defunct blog-post

https://www.algoo.fr/blog/2018/01/19/recouvrez-votre-liberte-en-quittant-slack-pour-un-mattermost-auto-heberge/ is 404 not found as of writing, today, Tuesday, March 10th, 2020